### PR TITLE
fix to error when mocking hookeddbcontext 

### DIFF
--- a/EFHooks/HookedDbContext.cs
+++ b/EFHooks/HookedDbContext.cs
@@ -30,25 +30,24 @@ namespace EFHooks
         /// Initializes a new instance of the <see cref="HookedDbContext" /> class, initializing empty lists of hooks.
         /// </summary>
         public HookedDbContext()
-            : base()
-        {
-            PreHooks = new List<IPreActionHook>();
-            PostHooks = new List<IPostActionHook>();
-            PostLoadHooks = new List<IPostLoadHook>();
-            ((IObjectContextAdapter)this).ObjectContext.ObjectMaterialized += ObjectMaterialized;
-        }
+            : base() {
+			PreHooks = new List<IPreActionHook>();
+			PostHooks = new List<IPostActionHook>();
+			PostLoadHooks = new List<IPostLoadHook>();
+			ListenToObjectMaterialized();
+		}
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="HookedDbContext" /> class, filling <see cref="PreHooks"/> and <see cref="PostHooks"/>.
-        /// </summary>
-        /// <param name="hooks">The hooks.</param>
-        public HookedDbContext(IHook[] hooks)
+		/// <summary>
+		/// Initializes a new instance of the <see cref="HookedDbContext" /> class, filling <see cref="PreHooks"/> and <see cref="PostHooks"/>.
+		/// </summary>
+		/// <param name="hooks">The hooks.</param>
+		public HookedDbContext(IHook[] hooks)
             : base()
         {
             PreHooks = hooks.OfType<IPreActionHook>().ToList();
             PostHooks = hooks.OfType<IPostActionHook>().ToList();
             PostLoadHooks = hooks.OfType<IPostLoadHook>().ToList();
-            ((IObjectContextAdapter)this).ObjectContext.ObjectMaterialized += ObjectMaterialized;
+			ListenToObjectMaterialized();
         }
 
         /// <summary>
@@ -62,7 +61,7 @@ namespace EFHooks
             PostHooks = new List<IPostActionHook>();
 
             PostLoadHooks = new List<IPostLoadHook>();
-            ((IObjectContextAdapter)this).ObjectContext.ObjectMaterialized += ObjectMaterialized;
+			ListenToObjectMaterialized();
         }
 
         /// <summary>
@@ -77,7 +76,7 @@ namespace EFHooks
             PostHooks = hooks.OfType<IPostActionHook>().ToList();
 
             PostLoadHooks = hooks.OfType<IPostLoadHook>().ToList();
-            ((IObjectContextAdapter)this).ObjectContext.ObjectMaterialized += ObjectMaterialized;
+			ListenToObjectMaterialized();
         }
 
         /// <summary>
@@ -238,5 +237,13 @@ namespace EFHooks
                 postLoadHook.HookObject(e.Entity, metadata);
             }
         }
+
+		private void ListenToObjectMaterialized() 
+		{
+			var oc = ((IObjectContextAdapter)this).ObjectContext;
+			if(null != oc)  //When mocking, this will be null
+				oc.ObjectMaterialized += this.ObjectMaterialized;
+		}
+
     }
 }


### PR DESCRIPTION
When Mocking a `HookedDbContext` [as recommended by Microsoft](https://msdn.microsoft.com/en-us/data/dn314429.aspx) we get a `NullReferenceException` due to `ObjectContext` being null when the constructor is called.

This PR adds a bit of leniency so that if this is null it does not try to wire events into it (none of the other methods should ever get called).